### PR TITLE
Add cookie storage to the http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"strconv"
 	"time"
 )
@@ -92,11 +93,18 @@ var (
 // This method only creates Client struct and does not start connecting to the
 // SSE endpoint.
 func New(url, lastEventID string) *Client {
+	// cookiejar.New always returns a nil error
+	jar, _ := cookiejar.New(nil)
+
 	return &Client{
 		URL:         url,
 		LastEventID: lastEventID,
 		Retry:       2 * time.Second,
 		HTTPClient: &http.Client{
+			// The jar stores and maintains cookies, which are
+			// useful to track clients state in a server/proxy
+			// for better sse stream management/connection
+			Jar: jar,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,


### PR DESCRIPTION
Currently there is an issue with horizontally scaled services that contain sse streams (especially cache/resync type). If multiple servers are providing sse streams, at one point or another they might be out of sync, even for a few events. If a client connects from a newer sse stream to the one, that is missing a few events, it will receive an error "missing events in cache". This error usually means that the client state is so old, that we cannot resync it, however in this case, the client is ahead of the server. The best approach for this would be to always direct clients to the same servers that were receiving their events before they disconnected. The nginx proxy allows to do that using cookies.

```
    SERVER A                          CLIENT
    ┌───────┐            0            ┌────┐
    │       │◄────────────────────────┤    │
    │ 1...4 │          1,2,3,4        │    │
    │       ├────────────────────────►│    │
    └───────┘                         │    │
                                      │    │
                                      │    │
    SERVER B                          │    │
    ┌───────┐            4            │    │
    │       │◄────────────────────────┤    │
    │ 1...2 │ missing events in cache │    │
    │       ├────────────────────────►│    │
    └───────┘                         └────┘
```

https://nginx.org/en/docs/http/ngx_http_upstream_module.html#sticky

For example, in live service, the "missing events in cache" error triggers a full state resync. Thats how it looks on a graph.
![image](https://user-images.githubusercontent.com/58231312/163718202-4c94ae10-323a-42cd-b8e0-049741842bec.png)